### PR TITLE
fix: update GoReleaser config to use non-deprecated syntax

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: >-
       {{ .ProjectName }}-
       {{- .Os }}-


### PR DESCRIPTION
## Summary
- Replace deprecated `archives.format` with `archives.formats` in GoReleaser v2 configuration
- Resolves deprecation warning: "DEPRECATED: archives.format should not be used anymore"

## Test plan
- [x] Validated configuration locally with `goreleaser check`
- [ ] CI/CD workflow should pass without deprecation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)